### PR TITLE
Disable zoom controls on home map

### DIFF
--- a/SatNOGS/static/js/home.js
+++ b/SatNOGS/static/js/home.js
@@ -1,5 +1,7 @@
 L.mapbox.accessToken = 'pk.eyJ1IjoicGllcnJvcyIsImEiOiJhTVZyWmE4In0.kl2j9fi24LDXfB3MNdN76w';
-var map = L.mapbox.map('map', 'pierros.jbf6la1j').setView([40, 0], 3);
+var map = L.mapbox.map('map', 'pierros.jbf6la1j',{
+    zoomControl: false
+}).setView([40, 0], 3);
 
 $('#successful a').click(function (e) {
 e.preventDefault()


### PR DESCRIPTION
We probably don't need zoom control on home map (currently overlaps with the top navbar).
