### PR TITLE
Automatic calculation of grid location

### DIFF
--- a/network/base/admin.py
+++ b/network/base/admin.py
@@ -9,7 +9,7 @@ class AntennaAdmin(admin.ModelAdmin):
 
 
 class StationAdmin(admin.ModelAdmin):
-    list_display = ('name', 'owner', 'lng', 'lat', 'location')
+    list_display = ('name', 'owner', 'lng', 'lat')
 
 
 class SatelliteAdmin(admin.ModelAdmin):

--- a/network/base/forms.py
+++ b/network/base/forms.py
@@ -7,5 +7,5 @@ class StationForm(forms.ModelForm):
     class Meta:
         model = Station
         fields = ['name', 'image', 'alt',
-                  'lat', 'lng', 'antenna', 'online']
+                  'lat', 'lng', 'location', 'antenna', 'online']
         image = forms.ImageField(required=False)

--- a/network/base/forms.py
+++ b/network/base/forms.py
@@ -7,5 +7,5 @@ class StationForm(forms.ModelForm):
     class Meta:
         model = Station
         fields = ['name', 'image', 'alt',
-                  'lat', 'lng', 'location', 'antenna', 'online']
+                  'lat', 'lng', 'qthlocator', 'location', 'antenna', 'online']
         image = forms.ImageField(required=False)

--- a/network/base/migrations/0015_station_qthlocator.py
+++ b/network/base/migrations/0015_station_qthlocator.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0014_auto_20150209_0846'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='station',
+            name='qthlocator',
+            field=models.CharField(max_length=255, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/network/base/models.py
+++ b/network/base/models.py
@@ -37,6 +37,7 @@ class Station(models.Model):
                                         MinValueValidator(-90)])
     lng = models.FloatField(validators=[MaxValueValidator(180),
                                         MinValueValidator(-180)])
+    qthlocator = models.CharField(max_length=255, null=True, blank=True)
     location = models.CharField(max_length=255, null=True, blank=True)
     antenna = models.ManyToManyField(Antenna, null=True, blank=True,
                                      help_text=('If you want to add a new Antenna '

--- a/network/static/js/gridsquare.js
+++ b/network/static/js/gridsquare.js
@@ -1,0 +1,45 @@
+/* This script calculates the grid locator based on the Maidenhead 
+ * Locator System.  It references the longitude and latitude fields
+ * in the Station Add/Edit view, calculating the grid square and adding
+ * that to the location field iff both lat/lon values exist and are
+ * valid. -cshields
+ */ 
+function gridsquare() {
+    var FIELD_IDENTIFIERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'H', 'K', 'L', 'M',
+                             'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
+
+    // starting points, the fields from the Station form
+    var latitude = document.getElementById('lat').value;
+    var longitude = document.getElementById('lng').value;
+
+    // this gets called any time one of the two lat/long fields
+    // have been changed. We only need to do the work if both
+    // fields have been entered with a proper entry, otherwise
+    // skip the cycles
+    if ((latitude !== '') &&
+            (latitude <= 90) &&
+            (latitude >= -90) &&
+            (longitude !== '') &&
+            (longitude <= 180) &&
+            (longitude >= -180)) {
+        
+        // to figure out the individual grid identifiers we make a mess
+        // of the longitude and latitude
+        var working_lon = ((+longitude + 180) % 20);
+        var lon_field = FIELD_IDENTIFIERS[Math.floor((+longitude + 180) / 20)];
+        var lon_square = Math.floor(working_lon / 2);
+        working_lon = Math.floor((working_lon % 2) * 12);
+        var lon_subsquare = FIELD_IDENTIFIERS[working_lon];
+    
+        var working_lat = ((+latitude + 90) % 10);
+        var lat_field = FIELD_IDENTIFIERS[Math.floor((+latitude + 90) / 10)];
+        var lat_square = Math.floor(working_lat);
+        working_lat = Math.floor((working_lat - Math.floor(working_lat)) * 24);
+        var lat_subsquare = FIELD_IDENTIFIERS[working_lat];
+        
+        // write the result, like EM69uf, to location field
+        var location = document.getElementById('location');
+        location.value = '' + lon_field + lat_field + lon_square + lat_square +
+            lon_subsquare.toLowerCase() + lat_subsquare.toLowerCase();
+    }
+}       

--- a/network/static/js/gridsquare.js
+++ b/network/static/js/gridsquare.js
@@ -37,9 +37,9 @@ function gridsquare() {
         working_lat = Math.floor((working_lat - Math.floor(working_lat)) * 24);
         var lat_subsquare = FIELD_IDENTIFIERS[working_lat];
         
-        // write the result, like EM69uf, to location field
-        var location = document.getElementById('location');
-        location.value = '' + lon_field + lat_field + lon_square + lat_square +
+        // write the result, like EM69uf, to qthlocator field
+        var qthlocator = document.getElementById('qthlocator');
+        qthlocator.value = '' + lon_field + lat_field + lon_square + lat_square +
             lon_subsquare.toLowerCase() + lat_subsquare.toLowerCase();
     }
 }       

--- a/network/templates/base/station_view.html
+++ b/network/templates/base/station_view.html
@@ -93,4 +93,5 @@
 
 {% block javascript %}
   <script src="{% static 'js/station_view.js' %}"></script>
+  <script src="{% static 'js/gridsquare.js' %}"></script>
 {% endblock javascript %}

--- a/network/templates/base/station_view.html
+++ b/network/templates/base/station_view.html
@@ -34,6 +34,12 @@
           </a>
         </span>
       </div>
+        <div class="gs-front-line">
+        <span class="label label-default">QTH Locator</span>
+        <span class="gs-front-data">
+          {{ station.qthlocator }}
+        </span>
+      </div>
       <div class="gs-front-line">
         <span class="label label-default">Location</span>
         <span class="gs-front-data">

--- a/network/templates/base/stations.html
+++ b/network/templates/base/stations.html
@@ -35,9 +35,9 @@
               </a>
             </td>
             <td>{{ station.name }}</td>
-            {% if station.location %}
+            {% if station.qthlocator %}
               <td title="{{ station.lat|floatformat:-3 }}, {{ station.lng|floatformat:-3 }}">
-                {{ station.location }}
+                {{ station.qthlocator }}
               </td>
             {% else %}
               <td>{{ station.lat|floatformat:-3 }}, {{ station.lng|floatformat:-3 }}</td>

--- a/network/templates/base/stations.html
+++ b/network/templates/base/stations.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load tags %}
 
+{% load staticfiles %}
+
 {% block title %}Ground Stations{% endblock %}
 
 {% block content %}
@@ -61,3 +63,7 @@
 <!-- Station Modal -->
 {% include 'includes/station_edit.html' %}
 {% endblock content %}
+
+{% block javascript %}
+  <script src="{% static 'js/gridsquare.js' %}"></script>
+{% endblock javascript %}

--- a/network/templates/includes/station_edit.html
+++ b/network/templates/includes/station_edit.html
@@ -38,13 +38,13 @@
           <div class="form-group">
             <label for="lat" class="col-sm-2 control-label">Latitude</label>
             <div class="col-sm-10">
-              <input value="{{ form.lat.value|default_if_none:"" }}" id="lat" type="text" class="form-control" name="lat" placeholder="Latitude">
+              <input value="{{ form.lat.value|default_if_none:"" }}" id="lat" type="text" class="form-control" name="lat" placeholder="Latitude" onchange="gridsquare()">
             </div>
           </div>
           <div class="form-group">
             <label for="lng" class="col-sm-2 control-label">Longtitude</label>
             <div class="col-sm-10">
-              <input value="{{ form.lng.value|default_if_none:"" }}" id="lng" type="text" class="form-control" name="lng" placeholder="Longtitude">
+              <input value="{{ form.lng.value|default_if_none:"" }}" id="lng" type="text" class="form-control" name="lng" placeholder="Longtitude" onchange="gridsquare()">
             </div>
           </div>
           <div class="form-group">
@@ -53,8 +53,8 @@
               <input class="form-control"
                      id="location"
                      type="text"
-                     placeholder="Geocoded location here"
-                     disabled>
+                     name="location"
+                     value="{{ form.location.value|default_if_none:"Geocoded location here" }}">
             </div>
           </div>
           <div class="form-group">

--- a/network/templates/includes/station_edit.html
+++ b/network/templates/includes/station_edit.html
@@ -53,8 +53,18 @@
               <input class="form-control"
                      id="location"
                      type="text"
-                     name="location"
-                     value="{{ form.location.value|default_if_none:"Geocoded location here" }}">
+                     placeholder="Geocoded address here"
+                     disabled>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="qthlocator" class="col-sm-2 control-label">QTH Locator</label>
+            <div class="col-sm-10">
+              <input class="form-control"
+                     id="qthlocator"
+                     type="text"
+                     name="qthlocator"
+                     value="{{ form.qthlocator.value|default_if_none:"Geocoded gridsquare here" }}">
             </div>
           </div>
           <div class="form-group">

--- a/network/templates/users/user_detail.html
+++ b/network/templates/users/user_detail.html
@@ -148,3 +148,7 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block javascript %}
+  <script src="{% static 'js/gridsquare.js' %}"></script>
+{% endblock javascript %}


### PR DESCRIPTION
With these changes, when a user enters a valid LAT/LON in a station, the maidenhead
grid locator is automatically calculated and entered into the "Location" field.
The grid square is updated likewise when a LAT/LON is changed.

The calculation of the grid square itself is done in the gridsquare.js file, which
reads the LAT/LON fields and puts the results in the Location field. This function
is triggered onchange for each of the LAT/LON input fields.  Caveat here is that
in order for the grid square to be saved, I had to change the Location field from
a "disabled" input box to a regular input box, otherwise django would not save the
output.

This js needed to be added wherever the station_edit.html may be called from (so,
stations.html, station_view.html, and user_detail.html)

The "location" field had to be added to forms.py for the saved grid square to show

resolves satnogs/satnogs-network#30

<!---
@huboard:{"order":98.0,"milestone_order":98,"custom_state":""}
-->
