### PR TITLE
fix rest api root urls

### DIFF
--- a/network/api/urls.py
+++ b/network/api/urls.py
@@ -1,16 +1,10 @@
-from django.conf.urls import patterns, url, include
 from rest_framework import routers
-
 from network.api import views
 
 
 router = routers.DefaultRouter()
 
-router.register(r'data', views.DataView)
-router.register(r'jobs', views.JobView)
+router.register(r'jobs', views.JobView, base_name='jobs')
+router.register(r'data', views.DataView, base_name='data')
 
-
-urlpatterns = patterns(
-    '',
-    url(r'^', include(router.urls))
-)
+urlpatterns = router.urls


### PR DESCRIPTION
Both data and job api urls are displayed as the same urls at https://network-dev.satnogs.org/api/ because they use the same data model, use 'base_name' parameter for router.register method to distinguish them from each other.

See https://github.com/tomchristie/django-rest-framework/issues/3267
