### PR TITLE
Remove invalid properties from SatelliteFactory

### DIFF
--- a/network/base/tests.py
+++ b/network/base/tests.py
@@ -58,11 +58,6 @@ class SatelliteFactory(factory.django.DjangoModelFactory):
     """Sattelite model factory."""
     norad_cat_id = fuzzy.FuzzyInteger(2000, 4000)
     name = fuzzy.FuzzyText()
-    tle0 = fuzzy.FuzzyText()
-    tle1 = fuzzy.FuzzyText()
-    tle2 = fuzzy.FuzzyText()
-    updated = fuzzy.FuzzyDateTime(now() - timedelta(days=3),
-                                  now() + timedelta(days=3))
 
     class Meta:
         model = Satellite

--- a/network/base/views.py
+++ b/network/base/views.py
@@ -178,9 +178,11 @@ def prediction_windows(request, sat_id, start_date, end_date):
         return JsonResponse(data, safe=False)
 
     try:
-        satellite = ephem.readtle(str(sat.latest_tle.tle0),
-                                  str(sat.latest_tle.tle1),
-                              str(sat.latest_tle.tle2))
+        satellite = ephem.readtle(
+            str(sat.latest_tle.tle0),
+            str(sat.latest_tle.tle1),
+            str(sat.latest_tle.tle2)
+        )
     except:
         data = {
             'error': 'No TLEs for this satellite yet.'


### PR DESCRIPTION
Removed invalid properties from `SatelliteFactory` in order to allow `initialize` management command to complete without errors. Also addresses a PEP8 E128 warning in `base/views.py`

Fixes #204 