### PR TITLE
Adding convenience links to observation view

### DIFF
--- a/network/static/css/app.css
+++ b/network/static/css/app.css
@@ -306,3 +306,7 @@ code.log p {
 .tle-data {
     margin-bottom: 15px;
 }
+
+.panel-title.link {
+    color: #337ab7;
+}

--- a/network/templates/base/observation_view.html
+++ b/network/templates/base/observation_view.html
@@ -35,7 +35,13 @@
         </thead>
         <tbody>
             <tr>
-              <td>{{ observation.satellite.norad_cat_id }} - {{ observation.satellite.name }}</td>
+              <td>
+                <a href="https://db.satnogs.org/satellite/{{ observation.satellite.norad_cat_id }}"
+                   target="_blank">
+                  {{ observation.satellite.norad_cat_id }}  - {{ observation.satellite.name }}
+                </a>
+                <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
+              </td>
               <td>{{ observation.transmitter.downlink_low|frq }}</td>
               <td>{{ observation.transmitter.mode|default:"-" }}</td>
               <td>{{ observation.start|date:"Y-m-d H:i:s" }}</br>{{ observation.end|date:"Y-m-d H:i:s" }}</td>
@@ -100,7 +106,10 @@
                data-groundstation="{{ data.ground_station }}">
             <div class="panel-heading">
               <h3 class="panel-title">
-                Data payload #{{ data.id }} from {{ data.ground_station }}
+                Data payload #{{ data.id }} from
+                <a class="panel-title link" href="{% url 'base:station_view' id=data.ground_station.id %}">
+                  {{ data.ground_station }}
+                </a>
               </h3>
             </div>
             <div class="panel-body">


### PR DESCRIPTION
I find myself often bouncing from an observation to the station
that made the recording, so added a link to the station in the
station name above the data payload view. In addition, made a
link to db.satnogs.org for the satellite, opening a new window
as this links out to a new site.