### PR TITLE
Force debug toolbar to show in dev

### DIFF
--- a/network/settings/dev.py
+++ b/network/settings/dev.py
@@ -7,12 +7,17 @@ DEBUG = True
 MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
-INTERNAL_IPS = ('127.0.0.1',)
+
+# override for INTERNAL_IPS, for docker and envs where that is dynamic
+def show_toolbar(request):
+    return True
+
 DEBUG_TOOLBAR_CONFIG = {
     'DISABLE_PANELS': [
         'debug_toolbar.panels.redirects.RedirectsPanel',
     ],
     'SHOW_TEMPLATE_CONTEXT': True,
+    'SHOW_TOOLBAR_CALLBACK': show_toolbar
 }
 
 # Apps


### PR DESCRIPTION
Django debug toolbar relies on INTERNAL_IPS for access control when
running in dev. This is difficult to match up in a virtualized and
dynamic environment (such as our instructions to run in docker).

This commit works around the IP check and forces the debug toolbar
to be active in dev, assuming that most dev is done in a local and
safe environment anyway.