### PR TITLE
Fix for duplicate entries in upcoming observations

### DIFF
--- a/network/base/views.py
+++ b/network/base/views.py
@@ -355,6 +355,15 @@ def station_view(request, id):
                     if tr is None:
                         break
 
+                    # bug in pyephem causes overhead sats to appear in the result
+                    # mixing next-pass data with current pass data, resulting in
+                    # satnogs/satnogs-network#199. As a workaround, pyephem does
+                    # return set time for current pass while rise time for next
+                    # pass so when this happens we want to toss the entry out
+                    # not a break as this sat might have another valid pass
+                    if ts < tr:
+                        pass
+
                     # using the angles module convert the sexagesimal degree into
                     # something more easily read by a human
                     elevation = format(math.degrees(altt), '.0f')


### PR DESCRIPTION
Due to a bug in pyephem when a satellite is overhead it will be
returned as a "next_pass" but with a mix of data between the
current and true next passes. This change tosses out any pass
that is currently overhead from being listed in the "upcoming
observations" list of station view. This should have no adverse
impact to the user as we are assuming the list to be "upcoming"
and not include what is currently overhead, nor would SatNogs be
able to schedule anything currently overhead.

fixes satnogs/satnogs-network#199