### PR TITLE
Switches to filter observations in the observations list

### DIFF
--- a/network/base/models.py
+++ b/network/base/models.py
@@ -235,7 +235,7 @@ class Observation(models.Model):
     # observation is vetted to be all bad data
     @property
     def has_no_data(self):
-        return self.data_set.filter(vetted_status='verified').count() == self.data_set.count()
+        return self.data_set.filter(vetted_status='no_data').count() == self.data_set.count()
 
     # observation has at least 1 payload left unvetted
     @property

--- a/network/static/js/btn_toggle.js
+++ b/network/static/js/btn_toggle.js
@@ -1,0 +1,18 @@
+$('.btn-toggle').click(function() {
+    $(this).find('.btn').toggleClass('active');  
+
+    if ($(this).find('.btn-primary').size()>0) {
+        $(this).find('.btn').toggleClass('btn-primary');
+    }
+    if ($(this).find('.btn-danger').size()>0) {
+        $(this).find('.btn').toggleClass('btn-danger');
+    }
+    if ($(this).find('.btn-success').size()>0) {
+        $(this).find('.btn').toggleClass('btn-success');
+    }
+    if ($(this).find('.btn-info').size()>0) {
+        $(this).find('.btn').toggleClass('btn-info');
+    }
+
+    $(this).find('.btn').toggleClass('btn-default');
+});

--- a/network/templates/base/observations.html
+++ b/network/templates/base/observations.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load tags %}
+{% load staticfiles %}
 
 {% block title %} - Observations{% endblock %}
 
@@ -10,6 +11,49 @@
       <a class="btn btn-primary pull-right" href="{% url 'base:observation_new' %}">New Observation</a>
     {% endif %}
   </h1>
+  <div>
+    <div>
+      <a class="btn btn-default" role="button" data-toggle="collapse"
+        href="#collapseFilters" aria-expanded="false" aria-controls="collapseFilters">
+       Filters <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
+      </a>
+    </div>
+    <div class="collapse" id="collapseFilters">
+      <div class="row">
+        <div class="col-xs-2">
+          <span class="label label-danger">
+            Bad Data <span class="glyphicon glyphicon-remove-sign" aria-hidden="true"></span>
+          </span>
+        </div>
+        <div class="btn-group btn-group-xs btn-toggle col-xs-2">
+          <button class="btn btn-primary active" data-toggle="collapse" data-target=".bad">On</button>
+          <button class="btn btn-default" data-toggle="collapse" data-target=".bad">Off</button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-2">
+          <span class="label label-warning">
+            Unvetted <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+          </span>
+        </div>
+        <div class="btn-group btn-group-xs btn-toggle col-xs-2">
+          <button class="btn btn-primary active" data-toggle="collapse" data-target=".unvetted">On</button>
+          <button class="btn btn-default" data-toggle="collapse" data-target=".unvetted">Off</button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-2">
+          <span class="label label-success">
+            Good Data <span class="glyphicon glyphicon-ok-sign" aria-hidden="true"></span>
+          </span>
+        </div>
+        <div class="btn-group btn-group-xs btn-toggle col-xs-2">
+          <button class="btn btn-primary active" data-toggle="collapse" data-target=".good">On</button>
+          <button class="btn btn-default" data-toggle="collapse" data-target=".good">Off</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <div class="row">
     <div class="col-md-12">
@@ -24,7 +68,13 @@
         </thead>
         <tbody>
           {% for observation in observations.all %}
-            <tr>
+            <tr{% if observation.has_no_data %}
+                  class="bad collapse in"
+                {% elif observation.has_verified_data %}
+                  class="good collapse in"
+                {% elif observation.has_unvetted_data %}
+                  class="unvetted collapse in"
+                {% endif %}>
               <td>
                 <a href="{% url 'base:observation_view' id=observation.id %}">
                   <span class="label
@@ -57,3 +107,7 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block javascript %}
+  <script src="{% static 'js/btn_toggle.js' %}"></script>
+{% endblock javascript %}


### PR DESCRIPTION
This commit adds a btn-toggle class which can be applied to a
btn-group to make a toggle switch (commonly "ON/OFF") in the
btn_toggle.js file.

This new class is implemented in the observations list to provide
a set of toggles to toggle the following:

Bad observations
Unvetted observations
Good observations

These controls are themselves collapsed by default, requiring a
click to open them up.