### PR TITLE
Fix filter collapse on selected satellite

### DIFF
--- a/network/templates/base/observations.html
+++ b/network/templates/base/observations.html
@@ -17,7 +17,7 @@
     <span class="glyphicon glyphicon-th-list" aria-hidden="true"></span> Filters
   </button>
 
-  <div class="collapse" id="collapseFilters">
+  <div class="collapse{% if norad %} in{% endif %}" id="collapseFilters">
     <div class="filter-section">
       <h4>Data:</h4>
       <button class="btn btn-default btn-sm active" data-toggle="collapse"


### PR DESCRIPTION
When you open an observations list after selecting a satellite
from the filter list, the filter will remain uncollapsed.
However, it is missing the "in" class, so this causes the need
for 2 clicks to attempt to collapse it, the second will not
cause the filter div to actually hide. This commit checks for
the selection and adds this class if it exists.

fixes satnogs/satnogs-network#238