### PR TITLE
Typo in gridsquare lookup table

### DIFF
--- a/network/static/js/gridsquare.js
+++ b/network/static/js/gridsquare.js
@@ -5,7 +5,7 @@
  * valid. -cshields
  */
 function gridsquare() {
-    var FIELD_IDENTIFIERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'H', 'K', 'L', 'M',
+    var FIELD_IDENTIFIERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
                              'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
 
     // starting points, the fields from the Station form


### PR DESCRIPTION
We have duplicate "H" entries in the grid square lookup table where the second should be "J"

fixes satnogs/satnogs-network#227