### PR TITLE
Fix scheduling from satellite view

### DIFF
--- a/network/base/views.py
+++ b/network/base/views.py
@@ -284,7 +284,8 @@ def observation_new(request):
             obs_filter['norad'] = norad
             obs_filter['start_date'] = start_date
             obs_filter['end_date'] = end_date
-            obs_filter['ground_station'] = ground_station
+            if ground_station:
+                obs_filter['ground_station'] = ground_station
         else:
             obs_filter['exists'] = False
 


### PR DESCRIPTION
Fixes a condition when trying to schedule an observation from the satellite modal - obs_filter is triggered but there is no ground station specified so that is passed on as 'undefined', where django expects an int to filter on. With this change, if there is no ground_station offered in obs_filter it is skipped. Now all new observation calculation methods are working again.