### PR TITLE
Filter and not predict on missing frequency capabilities

### DIFF
--- a/network/base/urls.py
+++ b/network/base/urls.py
@@ -15,10 +15,11 @@ base_urlpatterns = ([
     url(r'^observations/(?P<id>[0-9]+)/delete/$', views.observation_delete,
         name='observation_delete'),
     url(r'^observations/new/$', views.observation_new, name='observation_new'),
-    url(r'^prediction_windows/(?P<sat_id>[\w.@+-]+)/(?P<start_date>.+)/'
-        '(?P<end_date>.+)/(?P<station_id>[\w.@+-]+)/$',
+    url(r'^prediction_windows/(?P<sat_id>[\w.@+-]+)/(?P<transmitter>[\w.@+-]+)/'
+        '(?P<start_date>.+)/(?P<end_date>.+)/(?P<station_id>[\w.@+-]+)/$',
         views.prediction_windows, name='prediction_windows_filtered'),
-    url(r'^prediction_windows/(?P<sat_id>[\w.@+-]+)/(?P<start_date>.+)/(?P<end_date>.+)/$',
+    url(r'^prediction_windows/(?P<sat_id>[\w.@+-]+)/(?P<transmitter>[\w.@+-]+)/'
+        '(?P<start_date>.+)/(?P<end_date>.+)/$',
         views.prediction_windows, name='prediction_windows'),
     url(r'^data_verify/(?P<id>[0-9]+)/$', views.data_verify, name='data_verify'),
     url(r'^data_mark_bad/(?P<id>[0-9]+)/$', views.data_mark_bad, name='data_mark_bad'),

--- a/network/static/js/observation_new.js
+++ b/network/static/js/observation_new.js
@@ -51,11 +51,12 @@ $(document).ready( function(){
         $('#windows-data').empty();
         var start_time = $('#datetimepicker-start input').val();
         var end_time = $('#datetimepicker-end input').val();
+        var transmitter = $('#transmitter-selection').find(':selected').val();
 
-        var url = '/prediction_windows/' + satellite + '/' + start_time + '/' + end_time + '/';
+        var url = '/prediction_windows/' + satellite + '/' + transmitter + '/' + start_time + '/' + end_time + '/';
 
         if (obs_filter_station) {
-            url = '/prediction_windows/' + satellite + '/' + start_time + '/' + end_time + '/' + ground_station + '/';
+            url = '/prediction_windows/' + satellite + '/' + transmitter + '/' + start_time + '/' + end_time + '/' + ground_station + '/';
         }
 
         $.ajax({

--- a/network/static/js/station_view.js
+++ b/network/static/js/station_view.js
@@ -29,7 +29,7 @@ $(document).ready(function() {
         var centerY = ctx.canvas.height / 2;
         var canvasSize = Math.min(ctx.canvas.width, ctx.canvas.height);
         var altUnit = canvasSize/(2.5 * 90);
-        var fontRatio = 0.06;
+        var fontRatio = 0.07;
         var radius;
         var radians;
 
@@ -46,8 +46,8 @@ $(document).ready(function() {
             }
         }
 
-        ctx.strokeStyle = '#000000';
-        ctx.lineWidth = 2;
+        ctx.strokeStyle = '#444444';
+        ctx.lineWidth = 1;
         ctx.stroke();
         //Draw axis and letters
         radius = 96 * altUnit;
@@ -128,4 +128,26 @@ $(document).ready(function() {
             'marker-color': '#666',
         }
     }).addTo(map);
+
+    // Filters
+    $('#antenna-filter').submit(function () {
+        var the_form = $(this);
+
+        the_form.find('input[type="checkbox"]').each( function () {
+            var the_checkbox = $(this);
+
+
+            if( the_checkbox.is(':checked') === true ) {
+                the_checkbox.attr('value','1');
+            } else {
+                the_checkbox.prop('checked',true);
+                // Check the checkbox but change it's value to 0
+                the_checkbox.attr('value','0');
+            }
+        });
+    });
+
+    $('.filter-section input[type=checkbox]').change(function() {
+        $('#antenna-filter').submit();
+    });
 });

--- a/network/templates/base/station_view.html
+++ b/network/templates/base/station_view.html
@@ -163,10 +163,24 @@
   </div>
 
   <div class="collapse" id="collapseExample">
+    <div class="collapse in" id="collapseFilters">
+      <div class="filter-section">
+        <form id="antenna-filter" class="form-inline" method="get" action="{% url 'base:station_view' id=station.id %}">
+          <div class="form-group">
+            <h4>Filter:</h4>
+            <div class="btn-group" data-toggle="buttons">
+              <label class="btn btn-default btn-sm {% if unsupported_frequencies == '1' %}active{% endif %}"  aria-expanded="true" aria-controls="unsupported_frequencies">
+                <input type="checkbox" name="unsupported_frequencies" {% if unsupported_frequencies == '1' %}checked{% endif %} autocomplete="off">Include unsupported satellites
+              </label>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
   <table class="table table-hover table-responsive">
       <thead>
         <th>Name</th>
-        <th>Rise Time</th>
+        <th>Timeframe</th>
         <th>Rise, Max, Set</th>
         <th>Polar</th>
         <th></th>
@@ -180,7 +194,10 @@
               </a>
             </td>
             <td>
-              {{ nextpass.tr }} UTC
+              <span class="datetime-date">{{ nextpass.tr|date:"Y-m-d" }}</span>
+              <span class="datetime-time">{{ nextpass.tr|date:"H:i:s" }}</span><br>
+              <span class="datetime-date">{{ nextpass.ts|date:"Y-m-d" }}</span>
+              <span class="datetime-time">{{ nextpass.ts|date:"H:i:s" }}</span>
             </td>
             <td>
               {{ nextpass.azr }}° > {{ nextpass.altt }}° > {{ nextpass.azs }}°
@@ -190,7 +207,7 @@
             </td>
             <td>
               {% if nextpass.valid %}
-                <a href="{% url 'base:observation_new' %}?norad={{ nextpass.norad_cat_id }}&ground_station={{ station.id }}&start_date={{ nextpass.tr|truncatesecs }}&end_date={{ nextpass.ts|truncatesecs }}"
+                <a href="{% url 'base:observation_new' %}?norad={{ nextpass.norad_cat_id }}&ground_station={{ station.id }}&start_date={{ nextpass.tr|date:"Y/m/d H:i" }}&end_date={{ nextpass.ts|date:"Y/m/d H:i" }}"
                    class="btn btn-default">schedule</a>
               {% else %}
                 <a href="#" class="btn btn-default" disabled>schedule</a>


### PR DESCRIPTION
2 big changes here:

1 - provides filtering capabilities on station view to not show satellites missing transmitters that station is capable of receiving

2 - prediction_windows will now return only stations that are capable of receiving the selected transmitter.

fixes satnogs/satnogs-network#88

also per irc incorporates a fix for Pierros, https://github.com/ppapadeas/satnogs-network/commit/8c1c71d66f2b2bdf4a4264f7012c83423729cf3a