### PR TITLE
Keep preselected antennas when edit station

### DIFF
--- a/network/templates/includes/station_edit.html
+++ b/network/templates/includes/station_edit.html
@@ -71,7 +71,7 @@
             <div class="col-sm-10">
               <select multiple class="form-control" name="antenna">
                 {% for antenna in antennas %}
-                  <option value="{{ antenna.id }}">
+                  <option value="{{ antenna.id }}" {% if antenna in station.antenna.all %}selected{% endif %}>
                     {{ antenna.band}} {{ antenna.get_antenna_type_display }} | {{ antenna.frequency|frq }} - {{ antenna.frequency_max|frq }}
                   </option>
                 {% endfor %}


### PR DESCRIPTION
_Minor usability change._

When you try to update an existing station all camps are filled with the previous information except for the antennas.
This change preselect the existing antennas on the form