### PR TITLE
Hide filters if #collapseFilters in URL

### DIFF
--- a/network/static/js/observations.js
+++ b/network/static/js/observations.js
@@ -32,7 +32,10 @@ $(document).ready(function() {
     $('#station-selection').bind('keyup change', function() {
         $('#observation-filter').submit();
     });
-    if ($('#satellite-selection').val() || $('#observer-selection').val() || $('#station-selection').val()) {
+    if (window.location.hash == "#collapseFilters") {
+    
+        $('#collapseFilters').hide()
+    } else if ($('#satellite-selection').val() || $('#observer-selection').val() || $('#station-selection').val()) {
 
         $('#collapseFilters').show();
     }


### PR DESCRIPTION
The filters in a page like https://network.satnogs.org/observations/?norad=33493 when viewed in a narrow display take a lot of space placing the list of observations below the fold. This patch allows to at least link  to a page that has this hidden by default. Use case for this is Mission Control Projections with Tiled Application Windows.